### PR TITLE
Fix connection reset error handling

### DIFF
--- a/xray_api/exceptions.py
+++ b/xray_api/exceptions.py
@@ -35,7 +35,7 @@ class TagNotFoundError(XrayError):
 
 
 class ConnectionError(XrayError):
-    REGEXP = re.compile(r"Failed to connect to remote host|Socket closed|Broken pipe")
+    REGEXP = re.compile(r"Failed to connect to remote host|Socket closed|Broken pipe|Connection reset by peer")
 
     def __init__(self, details):
         super().__init__(details)


### PR DESCRIPTION
## Summary
- handle 'Connection reset by peer' as a connection error

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_686020ec82a4832ba0599a5f6baa73be