### PR TITLE
Fix node start timeout

### DIFF
--- a/app/xray/node.py
+++ b/app/xray/node.py
@@ -126,7 +126,11 @@ class ReSTXRayNode:
 
     @property
     def started(self):
-        res = self.make_request("/", timeout=3)
+        try:
+            res = self.make_request("/", timeout=3)
+        except NodeAPIError:
+            return False
+
         return res.get('started', False)
 
     @property


### PR DESCRIPTION
## Summary
- avoid raising error when `/` endpoint times out

## Testing
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_b_6860393fd1c0832bacc6bf481e010c99