### PR TITLE
Handle timeout in xray user ops

### DIFF
--- a/app/xray/operations.py
+++ b/app/xray/operations.py
@@ -32,7 +32,12 @@ def get_tls():
 def _add_user_to_inbound(api: XRayAPI, inbound_tag: str, account: Account):
     try:
         api.add_inbound_user(tag=inbound_tag, user=account, timeout=30)
-    except (xray.exc.EmailExistsError, xray.exc.ConnectionError, xray.exc.TagNotFoundError):
+    except (
+        xray.exc.EmailExistsError,
+        xray.exc.ConnectionError,
+        xray.exc.TagNotFoundError,
+        xray.exc.TimeoutError,
+    ):
         pass
 
 
@@ -40,7 +45,12 @@ def _add_user_to_inbound(api: XRayAPI, inbound_tag: str, account: Account):
 def _remove_user_from_inbound(api: XRayAPI, inbound_tag: str, email: str):
     try:
         api.remove_inbound_user(tag=inbound_tag, email=email, timeout=30)
-    except (xray.exc.EmailNotFoundError, xray.exc.ConnectionError, xray.exc.TagNotFoundError):
+    except (
+        xray.exc.EmailNotFoundError,
+        xray.exc.ConnectionError,
+        xray.exc.TagNotFoundError,
+        xray.exc.TimeoutError,
+    ):
         pass
 
 
@@ -48,11 +58,21 @@ def _remove_user_from_inbound(api: XRayAPI, inbound_tag: str, email: str):
 def _alter_inbound_user(api: XRayAPI, inbound_tag: str, account: Account):
     try:
         api.remove_inbound_user(tag=inbound_tag, email=account.email, timeout=30)
-    except (xray.exc.EmailNotFoundError, xray.exc.ConnectionError, xray.exc.TagNotFoundError):
+    except (
+        xray.exc.EmailNotFoundError,
+        xray.exc.ConnectionError,
+        xray.exc.TagNotFoundError,
+        xray.exc.TimeoutError,
+    ):
         pass
     try:
         api.add_inbound_user(tag=inbound_tag, user=account, timeout=30)
-    except (xray.exc.EmailExistsError, xray.exc.ConnectionError, xray.exc.TagNotFoundError):
+    except (
+        xray.exc.EmailExistsError,
+        xray.exc.ConnectionError,
+        xray.exc.TagNotFoundError,
+        xray.exc.TimeoutError,
+    ):
         pass
 
 

--- a/xray_api/proxyman.py
+++ b/xray_api/proxyman.py
@@ -26,7 +26,10 @@ class Proxyman(XRayBase):
     def alter_outbound(self, tag: str, operation: TypedMessage, timeout: int = None) -> bool:
         stub = command_pb2_grpc.HandlerServiceStub(self._channel)
         try:
-            stub.AlterInbound(command_pb2.AlterOutboundRequest(tag=tag, operation=operation), timeout=timeout)
+            stub.AlterOutbound(
+                command_pb2.AlterOutboundRequest(tag=tag, operation=operation),
+                timeout=timeout,
+            )
             return True
 
         except grpc.RpcError as e:


### PR DESCRIPTION
## Summary
- catch TimeoutError when modifying inbound users
- fix gRPC outbound method call

## Testing
- `python -m py_compile app/xray/operations.py xray_api/proxyman.py`

------
https://chatgpt.com/codex/tasks/task_b_6860cf54f308832baa1752754e9e7046